### PR TITLE
update for low obstacle detection

### DIFF
--- a/cabot_description/robots/cabot3-i1.urdf.xacro.xml
+++ b/cabot_description/robots/cabot3-i1.urdf.xacro.xml
@@ -92,6 +92,13 @@ SOFTWARE.
       <parent link="base_link"/>
       <child link="livox_link"/>
   </joint>
+  <link name="livox_footprint">
+  </link>
+  <joint name="livox_footprint_joint" type="fixed">
+      <origin xyz="0.10 0 -0.038" rpy="0 0 0"/>
+      <parent link="base_link"/>
+      <child link="livox_footprint"/>
+  </joint>
 
   <!-- IMU sensor description-->
   <xacro:imu_macro prefix="cabot/imu" frame="imu_frame"/>

--- a/cabot_description/robots/cabot3-m1.urdf.xacro.xml
+++ b/cabot_description/robots/cabot3-m1.urdf.xacro.xml
@@ -80,9 +80,16 @@ SOFTWARE.
   <link name="livox_link">
   </link>
   <joint name="livox_base" type="fixed">
-      <origin xyz="0.10 0 ${0.100-0.038}" rpy="3.1415926535 0 0"/>
+      <origin xyz="0.15 0 ${0.130-0.038}" rpy="3.1415926535 0 0"/>
       <parent link="base_link"/>
       <child link="livox_link"/>
+  </joint>
+  <link name="livox_footprint">
+  </link>
+  <joint name="livox_footprint_joint" type="fixed">
+      <origin xyz="0.15 0 -0.038" rpy="0 0 0"/>
+      <parent link="base_link"/>
+      <child link="livox_footprint"/>
   </joint>
 
   <!-- IMU sensor description-->

--- a/cabot_description/robots/cabot3-m2.urdf.xacro.xml
+++ b/cabot_description/robots/cabot3-m2.urdf.xacro.xml
@@ -80,9 +80,16 @@ SOFTWARE.
   <link name="livox_link">
   </link>
   <joint name="livox_base" type="fixed">
-      <origin xyz="0.10 0 ${0.100-0.038}" rpy="3.1415926535 0 0"/>
+      <origin xyz="0.15 0 ${0.130-0.038}" rpy="3.1415926535 0 0"/>
       <parent link="base_link"/>
       <child link="livox_link"/>
+  </joint>
+  <link name="livox_footprint">
+  </link>
+  <joint name="livox_footprint_joint" type="fixed">
+      <origin xyz="0.15 0 -0.038" rpy="0 0 0"/>
+      <parent link="base_link"/>
+      <child link="livox_footprint"/>
   </joint>
 
   <!-- IMU sensor description-->


### PR DESCRIPTION
This pull request fixed following items.
- add livox footprint link to detect low obstacles
- fix x, z of m1, m2 livox link

This update depends on following four other pull requests.
- [cabot](https://github.com/CMU-cabot/cabot/pull/187)
- [cabot-drivers](https://github.com/CMU-cabot/cabot-drivers/pull/27)
- [cabot-people](https://github.com/CMU-cabot/cabot-people/pull/17)
- [cabot-navigation](https://github.com/CMU-cabot/cabot-navigation/pull/72)

DCO 1.1 Signed-off-by: Tatsuya Ishihara <tisihara@jp.ibm.com>